### PR TITLE
bugfix isPojo when provided with an object with a circular reference

### DIFF
--- a/packages/is/pojo/src/lib/isPojo.spec.ts
+++ b/packages/is/pojo/src/lib/isPojo.spec.ts
@@ -18,4 +18,12 @@ describe('isPojo', () => {
       expect(isPojo(value)).toEqual(false);
     }
   );
+
+  test('should return FALSE for a circular reference', () => {
+    const obj = { a: 1, b: 2, c: [3, 4] };
+    // @ts-ignore
+    obj.c.push(obj);
+
+    expect(isPojo(obj)).toEqual(false);
+  });
 });

--- a/packages/is/pojo/src/lib/isPojo.ts
+++ b/packages/is/pojo/src/lib/isPojo.ts
@@ -36,9 +36,14 @@ const isAllowedJSONProperty = (value: any): boolean => {
 };
 
 export const isPojo = (value: any): boolean => {
-  if ((!isArray(value) && !isObject(value)) || isNil(value)) {
+  try {
+    if ((!isArray(value) && !isObject(value)) || isNil(value)) {
+      return false;
+    }
+
+    return isAllowedJSONProperty(value);
+  } catch {
+    // anything that isn't serializable must be false, such as a circular reference
     return false;
   }
-
-  return isAllowedJSONProperty(value);
 };

--- a/packages/to/pojo/src/lib/toPojo.spec.ts
+++ b/packages/to/pojo/src/lib/toPojo.spec.ts
@@ -302,5 +302,14 @@ describe('toPojo', () => {
       // @ts-ignore
       expect(toPojo(undefined)).toEqual(null);
     });
+
+    it('should NOT convert an object with a circular reference', () => {
+      const obj = { a: 1, b: 2, c: [3, 4] };
+      // @ts-ignore
+      obj.c.push(obj);
+
+      const fn = () => toPojo(obj);
+      expect(fn).toThrow('Cannot convert to JSON');
+    });
   });
 });

--- a/packages/to/pojo/src/lib/toPojo.ts
+++ b/packages/to/pojo/src/lib/toPojo.ts
@@ -135,9 +135,6 @@ export const toPojo = <T = Record<string, Serializables> | Serializables[]>(
     if (error.value) {
       zdError.value = error.value;
     }
-
-    // for every HOF that is for configuration (not argument currying) export a function using the default values
-
     throw zdError;
   }
 };


### PR DESCRIPTION
Ensure `isPojo()` return false when provided an object with a circular reference.